### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     branches: [ "main" ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest

--- a/src/Underground.Outbox.SourceGenerator/OutboxGenerator.cs
+++ b/src/Underground.Outbox.SourceGenerator/OutboxGenerator.cs
@@ -130,7 +130,7 @@ public sealed class OutboxGenerator : IIncrementalGenerator
 #pragma warning disable MA0006 // Use string.Equals instead of Equals operator
         bool hasMarker = assembly.GetAttributes()
             .Any(a => a.AttributeClass?.ToDisplayString() == MarkerAttributeFullName);
-#pragma warning restore MA0006 // Implement the functionality instead of throwing NotImplementedException
+#pragma warning restore MA0006 // Use string.Equals instead of Equals operator
 
         if (!hasMarker)
             return [];


### PR DESCRIPTION
Potential fix for [https://github.com/underground-dotnet/outbox/security/code-scanning/3](https://github.com/underground-dotnet/outbox/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is scoped to least privilege.  
Best fix here: add at workflow root (top-level) so it applies to all jobs by default.

For `.github/workflows/build.yml`, insert:

```yml
permissions:
  contents: read
```

immediately after the `on:` trigger section (before `jobs:`), preserving existing behavior while restricting token scope. No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
